### PR TITLE
fix lower clamp for speedcap not working

### DIFF
--- a/CrazyMew37-EndlessMode/extensions/objects/battle/battle_resources/stats.hooks.gd
+++ b/CrazyMew37-EndlessMode/extensions/objects/battle/battle_resources/stats.hooks.gd
@@ -76,8 +76,8 @@ func clamp_stat(chain: ModLoaderHookChain, stat: String, amount: float) -> float
 	match stat:
 		'speed':
 			if amount < SPEED_SETTING_STAT or SpeedCapSetting == 5:
-				return amount
+				return max(amount, 0.7)
 			else:
-				return SPEED_SETTING_STAT
+				return clamp(amount, 0.7, SPEED_SETTING_STAT)
 		_:
 			return clamped_amount


### PR DESCRIPTION
Fixes speed going below 0.7 minimum when using speed-reducing items (like massive speed reducing items from Green Folio).

Now uses clamp for any speed settings apart from the uncapped setting, which uses max, which should resolve the issue.